### PR TITLE
fix: ensure helia can parse content

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,7 +3,11 @@ FROM node:20.5.0
 
 WORKDIR /app
 
-RUN curl -s "https://get.kamu.dev" | sh
+# solve cmake not found error
+RUN apt-get update && apt-get -y install cmake protobuf-compiler
+
+# get working with macos
+RUN arch -arch x86_64 curl -s "https://get.kamu.dev" | sh
 RUN ln -s /root/.local/bin/kamu /usr/local/bin/kamu
 COPY package.json .
 

--- a/api/helia-dag-pb.js
+++ b/api/helia-dag-pb.js
@@ -1,0 +1,47 @@
+import * as codec from '@ipld/dag-pb'
+import { CID } from 'multiformats/cid'
+import { sha256 } from 'multiformats/hashes/sha2'
+
+/**
+ * we don't have a @helia/dag-pb yet, so this was simply copied over from @helia/dag-cbor and modified to work in js
+ *
+ * This has not been tested nor confirmed to work
+ */
+
+class DefaultDAGCBOR {
+  /**
+   * @type {DAGCBORComponents}
+   */
+  #components
+
+  /**
+   *
+   * @param {DAGCBORComponents} components
+   */
+  constructor (components) {
+    this.#components = components
+  }
+
+  async add (obj, options = {}) {
+    const buf = codec.encode(obj)
+    const hash = await (options.hasher ?? sha256).digest(buf)
+    const cid = CID.createV1(codec.code, hash)
+
+    await this.#components.blockstore.put(cid, buf, options)
+
+    return cid
+  }
+
+  async get (cid, options = {}) {
+    const buf = await this.#components.blockstore.get(cid, options)
+
+    return codec.decode(buf)
+  }
+}
+
+/**
+ * Create a {@link DAGPB} instance for use with {@link https://github.com/ipfs/helia Helia}
+ */
+export function dagPb (helia) {
+  return new DefaultDAGCBOR(helia)
+}

--- a/api/index.js
+++ b/api/index.js
@@ -5,8 +5,18 @@ const exec = util.promisify(Exec);
 import { CID } from 'multiformats/cid'
 import { createHelia } from 'helia'
 import { dagJson } from '@helia/dag-json'
+import { dagCbor } from '@helia/dag-cbor'
+
 import Fastify from 'fastify'
 import {initLibp2p} from './kubo.js'
+import debug from 'debug'
+// debug.enable('helia:*,libp2p:*')
+
+import * as IpldDagJson from '@ipld/dag-json'
+import * as IpldDagPB from '@ipld/dag-pb'
+import * as IpldDagCbor from '@ipld/dag-cbor'
+
+import {dagPb} from './helia-dag-pb.js'
 
 let heliaNode;
 let d;
@@ -18,17 +28,54 @@ const fastify = Fastify({
     logger: true
 })
 
-fastify.get('/', async (request, reply) => {
+// @ts-check
+const getOptions = {
+  schema: {
+    querystring: {
+      cid: {type: 'string'}
+    }
+  }
+
+}
+
+const mapFromCidCodeToHeliaWrapper = new Map()
+
+
+fastify.get('/', getOptions, async (request, reply) => {
+  // console.log(request.query)
+  console.log(`request.query: `, request.query);
+  if (request.query.cid === undefined) {
+    reply.type('application/json').code(500)
+    return { error: 'no cid provided' }
+  }
     // the hanging cid drawn from lilypad (for some reason works when using the chrome ipfs gateway extension and a running kubo node)
-    let Cid = CID.parse(String('QmY43r3bw9pJc28iFet42kAzVmtFuoa39kuxd4q4SG2gpz'))
+    // let Cid = CID.parse(String('QmY43r3bw9pJc28iFet42kAzVmtFuoa39kuxd4q4SG2gpz'))
+    let Cid = CID.parse(request.query.cid)
+
+    // need to find out what encoding is required for this CID
+    if (!mapFromCidCodeToHeliaWrapper.has(Cid.code)) {
+      reply.type('application/json').code(500)
+      return {
+        error: 'no codec found for cid',
+        needsCodecCode: {
+          decimal: Cid.code,
+          hex: `0x${Cid.code.toString(16)}`,
+        },
+        tableOfCodes: 'https://github.com/multiformats/multicodec/blob/master/table.csv'
+      }
+    }
+
+
     // "project apollo archives" a cid i grabbed from the explore in the gateway (doesn't hang though i should probably us dag-cbor as the error is Error: CBOR decode error "but it doesn't hang")
     //let Cid = CID.parse(String('QmSnuWmxptJZdLJpKRarxBMS2Ju2oANVrgbr2xWbie9b2D'))
     console.log('home route ping')
     console.log(d.get(Cid))
-    const res = await d.get(Cid)
+    const res = await d.get(Cid, {
+      // onProgress: (e) => console.log('progress', e)
+    })
     console.log('res', res)
     reply.type('application/json').code(200)
-    return { hello: 'world' }
+    return res
 })
 fastify.get('/hi', async (request, reply) => {
     const res = await d.get(hiCid)
@@ -48,12 +95,12 @@ fastify.get('/kamu', async (request, reply) => {
     } catch (e) {
         console.log('error', e)
     }
-    
+
 })
 
 fastify.addHook('onReady', async () => {
     console.log('booting');
-    ({libp2p, blockstore, datastore} = await initLibp2p());
+    const {client, libp2p, blockstore, datastore} = await initLibp2p();
     heliaNode = await createHelia({
         libp2p,
         blockstore,
@@ -61,11 +108,25 @@ fastify.addHook('onReady', async () => {
     })
     console.log('helia created')
     d = dagJson(heliaNode)
+
+    mapFromCidCodeToHeliaWrapper.set(IpldDagJson.code, d)
+    console.log(`IpldDagJson.code: `, IpldDagJson.code);
+    mapFromCidCodeToHeliaWrapper.set(IpldDagCbor.code, dagCbor(heliaNode))
+    console.log(`IpldDagCbor.code: `, IpldDagCbor.code);
+    // mapFromCidCodeToHeliaWrapper.set(IpldDagPB.code, dagPb(heliaNode))
+    // console.log(`IpldDagPB.code: `, IpldDagPB.code);
+
     hiCid = await d.add({"hello": "world"})
     console.log(hiCid)
+
+    // const result = await client.dag.get(CID.parse('QmY43r3bw9pJc28iFet42kAzVmtFuoa39kuxd4q4SG2gpz'))
+    // console.log(`result: `, result);
+    // for await (const data of client.cat('ipfs/QmY43r3bw9pJc28iFet42kAzVmtFuoa39kuxd4q4SG2gpz')) {
+    //   console.log(data)
+    // }
     //let Cid = CID.parse(String('QmPrszeDrL3rXD3LViZm4nWxz1HeaiyPr55PD99BajbCMS'))
     //const res = await d.get(Cid)
-    
+
 })
 
 fastify.listen({ host:'0.0.0.0', port: 3000 }, async (err, address) => {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@chainsafe/libp2p-noise": "^13.0.1",
         "@chainsafe/libp2p-yamux": "^5.0.0",
+        "@helia/dag-cbor": "^1.0.2",
         "@helia/dag-json": "^1.0.2",
         "@libp2p/delegated-content-routing": "^4.0.9",
         "@libp2p/delegated-peer-routing": "^4.0.12",
@@ -1961,6 +1962,75 @@
       "integrity": "sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==",
       "dependencies": {
         "fast-json-stringify": "^5.7.0"
+      }
+    },
+    "node_modules/@helia/dag-cbor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@helia/dag-cbor/-/dag-cbor-1.0.2.tgz",
+      "integrity": "sha512-HbrW+q1+F+tthN2vGf55Jhde5H7ZC9nY4R66qtPWrOIS3yzUNDSC/LolycqHGMawDU7oIZGwUiS2Hr1uJcJXzw==",
+      "dependencies": {
+        "@helia/interface": "^2.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "interface-blockstore": "^5.0.0",
+        "multiformats": "^12.0.1",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/dag-cbor/node_modules/@helia/interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-2.0.0.tgz",
+      "integrity": "sha512-LW8iRyits8/Tyi6KkZy6I8VydJZvdmeI5kxLanbLNgcCKrgE9bgrlUjR1cQXV5N+CDV8Rn9FRp6I7tYEYnTC0Q==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-bitswap": "^19.0.0",
+        "multiformats": "^12.0.1",
+        "progress-events": "^1.0.0"
+      }
+    },
+    "node_modules/@helia/dag-cbor/node_modules/@libp2p/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-2JtRGBXiGfm1t5XneUIXQ2JusW7QwyYmxsW7hSAYS5J73RQJUicpt5le5obVRt7+OM39ei+nWEuC6Xvm1ugHkw==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.2",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/@helia/dag-cbor/node_modules/ipfs-bitswap": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-19.0.0.tgz",
+      "integrity": "sha512-X0u7Y9dnRlP57EGNOF+RUtm2UkB3Nrx/NLLeUZ/VEEMWBC5iOFpBDvTxSNdEK366khbG8mXk2NJ1ko8jcKXETw==",
+      "dependencies": {
+        "@libp2p/interface": "^0.1.1",
+        "@libp2p/logger": "^3.0.1",
+        "@multiformats/multiaddr": "^12.1.0",
+        "@vascosantos/moving-average": "^1.1.0",
+        "any-signal": "^4.1.1",
+        "blockstore-core": "^4.0.0",
+        "events": "^3.3.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.1.0",
+        "it-foreach": "^2.0.2",
+        "it-length-prefixed": "^9.0.0",
+        "it-map": "^3.0.2",
+        "it-pipe": "^3.0.1",
+        "it-take": "^3.0.1",
+        "just-debounce-it": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "progress-events": "^1.0.0",
+        "protons-runtime": "^5.0.0",
+        "timeout-abort-controller": "^3.0.0",
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2",
+        "varint": "^6.0.0",
+        "varint-decoder": "^1.0.0"
       }
     },
     "node_modules/@helia/dag-json": {
@@ -6486,20 +6556,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-datachannel/node_modules/node-abi/node_modules/semver": {
-      "version": "7.3.7",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-datachannel/node_modules/npmlog": {
       "version": "4.1.2",
       "inBundle": true,
@@ -6631,6 +6687,20 @@
       "version": "5.1.2",
       "inBundle": true,
       "license": "MIT"
+    },
+    "node_modules/node-datachannel/node_modules/semver": {
+      "version": "7.5.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-datachannel/node_modules/set-blocking": {
       "version": "2.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^13.0.1",
     "@chainsafe/libp2p-yamux": "^5.0.0",
+    "@helia/dag-cbor": "^1.0.2",
     "@helia/dag-json": "^1.0.2",
     "@libp2p/delegated-content-routing": "^4.0.9",
     "@libp2p/delegated-peer-routing": "^4.0.12",

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,4 +1,4 @@
-services: 
+services:
   kamu:
     image: ghcr.io/kamu-data/kamu-base:latest-with-data
     container_name: "kamu"
@@ -27,17 +27,17 @@ services:
       - ipns_fuse:/ipns
     environment:
       - IPFS_PATH=/data/ipfs
-    ports: 
+    ports:
       # Swarm listens on all interfaces, so is remotely reachable.
       - 4001:4001/tcp
       - 4001:4001/udp
-      
+
       # The following ports only listen on the loopback interface, so are not remotely reachable by default.
       # If you want to override these or add more ports, see https://docs.docker.com/compose/extends/ .
-      
+
       # API port, which includes admin operations, so you probably don't want this remotely accessible.
       - 127.0.0.1:5001:5001
-      
+
       # HTTP Gateway
       - 127.0.0.1:8080:8080
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,10 @@
       "dependencies": {
         "@chainsafe/libp2p-noise": "^13.0.1",
         "@chainsafe/libp2p-yamux": "^5.0.0",
+        "@helia/dag-cbor": "^1.0.2",
         "@helia/dag-json": "^1.0.2",
         "@helia/unixfs": "^1.4.1",
+        "@ipld/dag-json": "^10.1.4",
         "@libp2p/delegated-content-routing": "^4.0.9",
         "@libp2p/delegated-peer-routing": "^4.0.12",
         "blockstore-core": "^4.3.4",
@@ -24,6 +26,7 @@
         "kubo-rpc-client": "^3.0.1",
         "libp2p": "^0.46.9",
         "multiformats": "^12.1.1",
+        "node-fetch": "^3.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -34,6 +37,7 @@
         "@typescript-eslint/eslint-plugin": "5.29.0",
         "@typescript-eslint/parser": "5.29.0",
         "builtin-modules": "3.3.0",
+        "debug": "^4.3.4",
         "esbuild": "0.17.3",
         "hardhat": "^2.17.2",
         "obsidian": "latest",
@@ -1365,6 +1369,19 @@
         "@ethersproject/strings": "^5.7.0"
       }
     },
+    "node_modules/@helia/dag-cbor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@helia/dag-cbor/-/dag-cbor-1.0.2.tgz",
+      "integrity": "sha512-HbrW+q1+F+tthN2vGf55Jhde5H7ZC9nY4R66qtPWrOIS3yzUNDSC/LolycqHGMawDU7oIZGwUiS2Hr1uJcJXzw==",
+      "dependencies": {
+        "@helia/interface": "^2.0.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@libp2p/interfaces": "^3.3.1",
+        "interface-blockstore": "^5.0.0",
+        "multiformats": "^12.0.1",
+        "progress-events": "^1.0.0"
+      }
+    },
     "node_modules/@helia/dag-json": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@helia/dag-json/-/dag-json-1.0.2.tgz",
@@ -1640,16 +1657,24 @@
       }
     },
     "node_modules/@ipld/dag-json": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.1.3.tgz",
-      "integrity": "sha512-c0PJE+cDnsYfyuWMdTTwkzMvxjthEwWD+0u6ApQfXrs+GTcxeYh+Hefd0xE9L4fb2Trr1DGA1a/iia4PAS3Mpg==",
+      "version": "10.1.4",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.1.4.tgz",
+      "integrity": "sha512-Vgm739qPQ7P8cstna60oYx19tzJzep+Uy7yWi80dzIOygibfVaaRZ07M6qbHP+C9BJl81GNFaXy2Plr0y7poBA==",
       "dependencies": {
-        "cborg": "^2.0.1",
+        "cborg": "^4.0.0",
         "multiformats": "^12.0.1"
       },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-json/node_modules/cborg": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.0.3.tgz",
+      "integrity": "sha512-poLvpK30KT5KI8gzDx3J/IuVCbsLqMT2fEbOrOuX0H7Hyj8yg5LezeWhRh9aLa5Z6MfPC5sriW3HVJF328M8LQ==",
+      "bin": {
+        "cborg": "lib/bin.js"
       }
     },
     "node_modules/@ipld/dag-pb": {
@@ -4708,6 +4733,14 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/datastore-core": {
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-9.2.3.tgz",
@@ -5506,6 +5539,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5596,6 +5651,17 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fp-ts": {
@@ -6759,6 +6825,25 @@
       "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
       "peerDependencies": {
         "node-fetch": "*"
+      }
+    },
+    "node_modules/ipfs-utils/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/ipns": {
@@ -8731,23 +8816,39 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-forge": {
@@ -9234,6 +9335,25 @@
       },
       "bin": {
         "rabin-wasm": "cli/bin.js"
+      }
+    },
+    "node_modules/rabin-wasm/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/randombytes": {
@@ -10158,6 +10278,14 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",
     "builtin-modules": "3.3.0",
+    "debug": "^4.3.4",
     "esbuild": "0.17.3",
     "hardhat": "^2.17.2",
     "obsidian": "latest",
@@ -27,8 +28,10 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^13.0.1",
     "@chainsafe/libp2p-yamux": "^5.0.0",
+    "@helia/dag-cbor": "^1.0.2",
     "@helia/dag-json": "^1.0.2",
     "@helia/unixfs": "^1.4.1",
+    "@ipld/dag-json": "^10.1.4",
     "@libp2p/delegated-content-routing": "^4.0.9",
     "@libp2p/delegated-peer-routing": "^4.0.12",
     "blockstore-core": "^4.3.4",
@@ -40,6 +43,7 @@
     "kubo-rpc-client": "^3.0.1",
     "libp2p": "^0.46.9",
     "multiformats": "^12.1.1",
+    "node-fetch": "^3.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }


### PR DESCRIPTION
btw, the fastify path at `/` now requires a cid query parameter , so you should request it like: 

http://localhost:3000/?cid=baguqeerasords4njcts6vs7qvdjfcvgnume4hqohf65zsfguprqphs3icwea


The CID you were using, `QmY43r3bw9pJc28iFet42kAzVmtFuoa39kuxd4q4SG2gpz`, was not able to be fetched from the network easily (maybe it's not pinned on a provider) which may have been causing some of your problems, but the CIDs at explore.ipld.io are great for testing, because those are pinned and are probably much more popular on the network.

The cid in the localhost link above is the one on explore.ipld.io for dag-json: https://explore.ipld.io/#/explore/baguqeerasords4njcts6vs7qvdjfcvgnume4hqohf65zsfguprqphs3icwea, and that content can be retrieved without issue.